### PR TITLE
Fix API edge cases for shopcarts

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -234,6 +234,10 @@ class Shopcart(db.Model):
                 "Invalid Shopcart: body of request contained bad or no data "
                 + str(error)
             ) from error
+        except ValueError as error:
+            raise DataValidationError(
+                f"Invalid Shopcart: invalid status [{data.get('status')}]"
+            ) from error
         return self
 
     ##################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -173,7 +173,8 @@ def update_shopcarts(shopcart_id):
     shopcart = Shopcart.find(shopcart_id)
     if not shopcart:
         abort(
-            status.HTTP_404_NOT_FOUND, f"Account with id '{shopcart_id}' was not found."
+            status.HTTP_404_NOT_FOUND,
+            f"Shopcart with id '{shopcart_id}' was not found.",
         )
 
     # Update from the json in the body of the request
@@ -291,12 +292,20 @@ def get_items(shopcart_id, item_id):
         "Request to retrieve Item %s for Shopcart id: %s", (item_id, shopcart_id)
     )
 
-    # See if the item exists and abort if it doesn't
-    item = Item.find(item_id)
-    if not item:
+    # See if the shopcart exists and abort if it doesn't
+    shopcart = Shopcart.find(shopcart_id)
+    if not shopcart:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Shopcart with id '{item_id}' could not be found.",
+            f"Shopcart with id '{shopcart_id}' could not be found.",
+        )
+
+    # See if the item exists and belongs to this shopcart
+    item = Item.find(item_id)
+    if not item or item.shopcart_id != shopcart.id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Item with id '{item_id}' was not found in shopcart '{shopcart_id}'.",
         )
 
     return jsonify(item.serialize()), status.HTTP_200_OK
@@ -317,12 +326,20 @@ def update_items(shopcart_id, item_id):
     )
     check_content_type("application/json")
 
-    # See if the item exists and abort if it doesn't
-    item = Item.find(item_id)
-    if not item:
+    # See if the shopcart exists and abort if it doesn't
+    shopcart = Shopcart.find(shopcart_id)
+    if not shopcart:
         abort(
             status.HTTP_404_NOT_FOUND,
-            f"Shopcart with id '{item_id}' could not be found.",
+            f"Shopcart with id '{shopcart_id}' could not be found.",
+        )
+
+    # See if the item exists and belongs to this shopcart
+    item = Item.find(item_id)
+    if not item or item.shopcart_id != shopcart.id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Item with id '{item_id}' was not found in shopcart '{shopcart_id}'.",
         )
 
     # Update from the json in the body of the request

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -409,3 +409,12 @@ class TestItem(TestCase):
 
         found = Shopcart.find_by_status(CartStatus.CHECKED_OUT)
         self.assertEqual(found, [])
+
+    def test_shopcart_deserialize_invalid_status(self):
+        """It should raise DataValidationError for an invalid shopcart status"""
+        shopcart = Shopcart()
+        self.assertRaises(
+            DataValidationError,
+            shopcart.deserialize,
+            {"name": "TestCart", "status": "not-a-real-status"},
+        )

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -400,6 +400,8 @@ class TestShopcartService(TestCase):
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        data = resp.get_json()
+        self.assertIn("Shopcart", data["message"])
 
     def test_create_item_shopcart_not_found(self):
         """It should return 404 when adding an item to a non-existent shopcart"""
@@ -420,12 +422,39 @@ class TestShopcartService(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_get_item_wrong_shopcart(self):
+        """It should return 404 when the item belongs to a different shopcart"""
+        shopcart_one = self._create_shopcarts(1)[0]
+        shopcart_two = self._create_shopcarts(1)[0]
+        item = ItemFactory(shopcart_id=shopcart_one.id)
+        item.create()
+
+        resp = self.client.get(
+            f"{BASE_URL}/{shopcart_two.id}/items/{item.id}",
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_update_item_not_found(self):
         """It should return 404 when updating a non-existent item"""
         shopcart = self._create_shopcarts(1)[0]
         resp = self.client.put(
             f"{BASE_URL}/{shopcart.id}/items/999999",
             json={"product_id": "p1", "name": "Item", "quantity": 1, "price": 9.99},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_item_wrong_shopcart(self):
+        """It should return 404 when updating an item in the wrong shopcart"""
+        shopcart_one = self._create_shopcarts(1)[0]
+        shopcart_two = self._create_shopcarts(1)[0]
+        item = ItemFactory(shopcart_id=shopcart_one.id)
+        item.create()
+
+        resp = self.client.put(
+            f"{BASE_URL}/{shopcart_two.id}/items/{item.id}",
+            json=item.serialize(),
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
@@ -450,6 +479,25 @@ class TestShopcartService(TestCase):
     def test_bad_request_from_invalid_data(self):
         """It should return 400 when request data is invalid"""
         resp = self.client.post(BASE_URL, json={}, content_type="application/json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_shopcart_invalid_status(self):
+        """It should return 400 when creating a shopcart with an invalid status"""
+        resp = self.client.post(
+            BASE_URL,
+            json={"name": "BrokenCart", "status": "nope"},
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_shopcart_invalid_status(self):
+        """It should return 400 when updating a shopcart with an invalid status"""
+        shopcart = self._create_shopcarts(1)[0]
+        resp = self.client.put(
+            f"{BASE_URL}/{shopcart.id}",
+            json={"name": shopcart.name, "userid": shopcart.userid, "status": "nope"},
+            content_type="application/json",
+        )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     ######################################################################


### PR DESCRIPTION
## Summary
- validate that item read/update endpoints check item ownership against the requested shopcart
- return 400 for invalid shopcart status values
- clean up one inconsistent 404 message in the update flow
- add route/model tests for these edge cases

## Verification
- python -m compileall service tests
