### PR TITLE
Add PostgreSQL secret and route for OpenShift deployment

### DIFF
--- a/k8s/postgres-secret.yaml
+++ b/k8s/postgres-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+type: Opaque
+stringData:
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_DB: postgres
+  DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres

--- a/k8s/postgres/pv.yaml
+++ b/k8s/postgres/pv.yaml
@@ -8,4 +8,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: local-path

--- a/k8s/route.yaml
+++ b/k8s/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: shopcarts
+  labels:
+    app: shopcarts
+spec:
+  to:
+    kind: Service
+    name: shopcarts
+  port:
+    targetPort: 8080


### PR DESCRIPTION
This PR implements Story #74 by configuring PostgreSQL and exposing the application via an OpenShift Route.